### PR TITLE
Add support for dumping sdboot style .SEC files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod include;
+mod sdboot;
 use std::path::{Path, PathBuf};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Cursor, Seek, SeekFrom, Write};
@@ -17,6 +18,9 @@ struct Args {
     /// Save .TXT and TDI files
     #[arg(short = 's')]
     save_extra: bool,
+
+    #[arg(short = 'd')]
+    sdboot: bool,
 
     input_file: String,
     output_folder: Option<String>,
@@ -64,6 +68,52 @@ fn parse_tdi_to_modules(tdi_data: Vec<u8>, verbose: bool) -> Result<Vec<TdiTgtIn
     Ok(modules)
 }
 
+fn dump_sdboot(file_path: PathBuf, output_folder: &String) -> Result<(), Box<dyn std::error::Error>> {
+
+    let mut file = File::open(file_path)?;
+
+
+    let mut secfile_hdr_reader = Cursor::new(sdboot::decipher(&read_exact(&mut file, sdboot::SdbootSecHeader::SIZE)?));
+    
+    let secfile_header: sdboot::SdbootSecHeader = secfile_hdr_reader.read_be()?;
+
+    let key_id = secfile_header.key_id();
+    if key_id != 0 && key_id != 1 {
+        return Err(format!("Invalid sdboot sec key id! got {} but must be 0 or 1", key_id).into());
+    }
+
+    println!("File info -\nKey ID: {}\nFile count: {}\n", secfile_header.key_id(), secfile_header.num_files());
+
+    fs::create_dir_all(output_folder)?;
+
+    for i in 0..secfile_header.num_files() {
+        
+        let mut entry_header_reader = Cursor::new(sdboot::decrypt(key_id, &read_exact(&mut file, sdboot::SdbootEntryHeader::SIZE)?)?);
+        let entry_header: sdboot::SdbootEntryHeader = entry_header_reader.read_be()?;
+
+        let entry_name = entry_header.name()?;
+        let entry_size= entry_header.file_size();
+
+        println!("File: {} Size: {:#x}", entry_name, entry_size);
+
+        let file_data=sdboot::decrypt(key_id, &read_exact(&mut file, entry_size)?)?;
+        
+        // this has a 0x20 byte header. seems to contain some number as string again. not sure if
+        // its useful
+        let actual_file_data = &file_data[0x20..];
+
+        let output_path = Path::new(&output_folder).join(entry_name);
+
+
+        let mut out_file = OpenOptions::new().read(true).write(true).create(true).open(output_path)?;
+        out_file.write_all(actual_file_data)?;
+
+    }
+
+
+    Ok(())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("sddl_dec Tool Version 6.0");
     let args = Args::parse();
@@ -78,6 +128,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         format!("_{}", file_path.file_name().and_then(|s| s.to_str()).unwrap())
     };
     println!("Output folder: {}\n", output_folder);
+
+    if args.sdboot {
+        return dump_sdboot(file_path, &output_folder);
+    }
+
 
     let save_extra = args.save_extra;
     let verbose = args.verbose;

--- a/src/sdboot.rs
+++ b/src/sdboot.rs
@@ -1,0 +1,113 @@
+use std::{string::FromUtf8Error};
+use binrw::{BinRead};
+use aes::{Aes128, cipher::block_padding::NoPadding};
+use cbc::{Decryptor, cipher::{BlockDecryptMut, KeyIvInit}};
+type Aes128CbcDec = Decryptor<Aes128>;
+
+
+// -- utils --
+fn string_from_bytes(buf: &[u8]) -> String {
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..end]).to_string()
+}
+
+// keys is stored in PEAKSBT.bin(0x300000 in nand afaik) 
+// the actual keys are encrypted with this key and iv 
+// key = c2 a4 21 f6 ad eb 44 be b0 fd a6 8c 23 4b b3 c5,
+// iv  = e9 8e c6 8c 32 6f d3 95 07 c8 d7 5e f1 b1 b1 42)
+
+// decrypted keys is as follows:
+// key id 0
+// key = 2e 2a 33 62 33 e5 5a ba f5 ff ec 54 f8 ab 71 25
+// iv = 2c a4 b4 7a ff cb 1a e8 e1 ea 2d 9e f5 12 62 9a
+//
+// key id 1
+// key = 24 5e 8d e8 f4 99 b0 f9 6e c1 55 b6 08 e2 42 f3
+// iv  = 3e 8f 29 d4 ba e7 76 a5 18 a7 b6 3c 42 ca 1b 43
+//
+//
+
+struct KeyEntry {
+    key: [u8; 0x10],
+    iv: [u8; 0x10],
+}
+
+const KEYS: [KeyEntry; 2] = [
+    KeyEntry {
+        key: [0x2e, 0x2a, 0x33, 0x62, 0x33, 0xe5, 0x5a, 0xba, 0xf5, 0xff, 0xec, 0x54, 0xf8, 0xab, 0x71, 0x25 ],
+        iv: [0x2c, 0xa4, 0xb4, 0x7a, 0xff, 0xcb, 0x1a, 0xe8, 0xe1, 0xea, 0x2d, 0x9e, 0xf5, 0x12, 0x62, 0x9a]
+    },
+    KeyEntry {
+        key: [0x24, 0x5e, 0x8d, 0xe8, 0xf4, 0x99, 0xb0, 0xf9, 0x6e, 0xc1, 0x55, 0xb6, 0x08, 0xe2, 0x42, 0xf3],
+        iv: [0x3e, 0x8f, 0x29, 0xd4, 0xba, 0xe7, 0x76, 0xa5, 0x18, 0xa7, 0xb6, 0x3c, 0x42, 0xca, 0x1b, 0x43]
+    }
+];
+
+pub fn decrypt(key_id: u16, encrypted_data: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let key_data = &KEYS[key_id as usize];
+
+    let mut data = encrypted_data.to_vec();
+    let decryptor = Aes128CbcDec::new(&key_data.key.into(), &key_data.iv.into());
+    let decrypted = decryptor.decrypt_padded_mut::<NoPadding>(&mut data)
+        .map_err(|e| format!("!!Decryption error!!: {:?}", e))?;
+    
+    Ok(decrypted.to_vec())
+}
+
+
+pub fn decipher(s: &[u8]) -> Vec<u8> {
+    // deciphering algorithm seems same but diffrent for sdboot?
+    
+    let mut out = s.to_vec();
+    let mut key: u16 = 0x0388;
+
+    for i in 0..s.len(){
+        out[i] = (key >> 8) as u8 ^ s[i];
+
+        key = key.wrapping_add(0x96a3).wrapping_add(s[i] as u16);
+    }
+    
+    out
+}
+
+
+#[derive(Debug, BinRead)]
+pub struct SdbootSecHeader {
+    num_files_str_bytes: [u8; 4],
+    key_id_str_bytes: [u8; 4],
+    _0x0008: [u8; 4],
+    _0x000c: [u8; 4],
+    _0x0010: [u8; 16],
+}
+
+impl SdbootSecHeader {
+    pub const SIZE: usize = 0x20;
+
+    pub fn num_files(&self) -> u32 {
+        let string = string_from_bytes(&self.num_files_str_bytes);
+        string.parse().unwrap()
+    }
+    pub fn key_id(&self) -> u16 {
+        let string = string_from_bytes(&self.key_id_str_bytes);
+        string.parse().unwrap()
+    }
+}
+
+#[derive(Debug, BinRead)]
+pub struct SdbootEntryHeader {
+    pub file_name: [u8; 0x34],
+    file_size_str_bytes: [u8; 0xc],
+}
+
+impl SdbootEntryHeader {
+    pub const SIZE: usize = 0x40;
+
+    pub fn name(&self) -> Result<String, FromUtf8Error> {
+        let end = self.file_name.iter().position(|&b| b == 0).unwrap_or(self.file_name.len());
+        String::from_utf8(self.file_name[..end].to_vec())
+    }
+    pub fn file_size(&self) -> usize {
+        let string = string_from_bytes(&self.file_size_str_bytes);
+        string.parse().unwrap()
+    }
+}


### PR DESCRIPTION
Adds support for dumping sdboot style sec files. (older format?)

Seems like most peaks style devices supports it by either changing boot mode in service menu like shown in sample instructions, or by a pin on the debug header at the back of the display. 

Code to decrypt and load sdboot rom is handled in PEAKSBT. Looks like the "decipher" program in the sample also has the same decryption code, but this time for SDDL_B.SEC.

Sample was sourced [here](https://www.avsforum.com/threads/thx-color-decoding-fix-g10-and-v10.1186568/page-111?post_id=34255266#post-34255266). Is linux instead of freebsd.